### PR TITLE
Feature/story display

### DIFF
--- a/src/components/Bookshelf/Book.js
+++ b/src/components/Bookshelf/Book.js
@@ -24,8 +24,7 @@ const Book = ({ story, onClick}) => {
       className="book" 
       style={{ backgroundImage: `url(${spine})` }}
       role="button"
-      onClick={(event) => {
-        event.preventDefault()
+      onClick={() => {
         onClick(story)
       }}
     >

--- a/src/components/Bookshelf/Book.js
+++ b/src/components/Bookshelf/Book.js
@@ -13,7 +13,7 @@ import book7 from "../../assets/bookspine7.png";
 const bookSpines = [book1, book2, book3, book4, book5, book6, book7];
 
 const getBookSpine = () => {
-  const random = Math.floor(Math.random() * Math.floor(5));
+  const random = Math.floor(Math.random() * 6);
   return bookSpines[random];
 };
 

--- a/src/components/Bookshelf/Book.js
+++ b/src/components/Bookshelf/Book.js
@@ -24,7 +24,10 @@ const Book = ({ story, onClick}) => {
       className="book" 
       style={{ backgroundImage: `url(${spine})` }}
       role="button"
-      onClick={() => onClick(story)}
+      onClick={(event) => {
+        event.preventDefault()
+        onClick(story)
+      }}
     >
       <span className="title">{story.title}</span>
       <span className="prompt">{story.prompt}</span>

--- a/src/components/Bookshelf/Book.test.js
+++ b/src/components/Bookshelf/Book.test.js
@@ -1,0 +1,38 @@
+import React from "react"
+import { screen, render, fireEvent } from "@testing-library/react"
+import moment from 'moment'
+import "@testing-library/jest-dom"
+import Book from "./Book"
+import testData from '../../assets/testData/testData'
+
+describe('Book button', () => {
+  let story, mockClick, book 
+
+  beforeEach(() => {
+    story = testData.stories[0]
+    mockClick = jest.fn()
+    render(<Book story={story} onClick={mockClick}/>)
+    book = screen.getByRole('button')
+  })
+
+  it('should render a button', () => {
+    expect(book).toBeInTheDocument()
+  })
+
+  it('should display the title of the story on the button', () => {
+    const title = screen.getByText('Greyson has a good morning')
+    expect(title).toBeInTheDocument()
+  })
+
+  it('should display the date the story was last updated', () => {
+    const expectedText = moment(story.updated_at).format('MMM YYYY')
+    const date = screen.getByText(expectedText)
+    expect(date).toBeInTheDocument()
+  })
+
+  it(`should fire a function with it's story when clicked`, () => {
+    fireEvent.click(book)
+    expect(mockClick).toHaveBeenCalledTimes(1)
+    expect(mockClick).toHaveBeenCalledWith(story)
+  })
+})

--- a/src/components/Bookshelf/Bookshelf.js
+++ b/src/components/Bookshelf/Bookshelf.js
@@ -3,7 +3,7 @@ import Book from './Book'
 import './Bookshelf.scss'
 
 const Bookshelf = ({ stories, onClick }) => {
-  
+
   const booksSelection = stories.map((story, i) => {
     return (
       <Book story={story} onClick={onClick} key={i}/>
@@ -11,10 +11,8 @@ const Bookshelf = ({ stories, onClick }) => {
   })
     
   return (
-    <section>
-      <span className="bookContainer">
-        {booksSelection}
-      </span>
+    <section className="bookContainer">
+      {booksSelection}
     </section>
   )
 }

--- a/src/components/Bookshelf/Bookshelf.test.js
+++ b/src/components/Bookshelf/Bookshelf.test.js
@@ -6,12 +6,12 @@ describe('Bookshelf component', () => {
   let stories
 
   beforeEach(() => {
-    stories = ;
+    // stories = ;
   })
 })
 
 it("renders learn react link", () => {
-  const { getByText } = render(<App />);
-  const linkElement = getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+//   const { getByText } = render(<App />);
+//   const linkElement = getByText(/learn react/i);
+//   expect(linkElement).toBeInTheDocument();
 });

--- a/src/components/Bookshelf/Bookshelf.test.js
+++ b/src/components/Bookshelf/Bookshelf.test.js
@@ -1,17 +1,31 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import {screen, render, fireEvent} from "@testing-library/react";
 import Bookshelf from "./Bookshelf";
+import testData from '../../assets/testData/testData'
 
 describe('Bookshelf component', () => {
-  let stories
+  let stories, mockClick
 
   beforeEach(() => {
-    // stories = ;
+    stories = testData.stories
+    mockClick = jest.fn()
+    render(<Bookshelf stories={stories} onClick={mockClick}/>)
+  })
+
+  it('should render a button for each story', () => {
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(4)
+  })
+
+  it('should pass story info to each book to be rendered', () => {
+    const title = screen.getByText('Birdhouse in Your Soul')
+    expect(title).toBeInTheDocument()
+  })
+  
+  it('should pass an onClick function to books', () => {
+    const title = screen.getByText('Birdhouse in Your Soul')
+    fireEvent.click(title)
+    expect(mockClick).toHaveBeenCalledTimes(1)
   })
 })
 
-it("renders learn react link", () => {
-//   const { getByText } = render(<App />);
-//   const linkElement = getByText(/learn react/i);
-//   expect(linkElement).toBeInTheDocument();
-});

--- a/src/components/LibraryView/LibraryView.js
+++ b/src/components/LibraryView/LibraryView.js
@@ -2,13 +2,19 @@ import { getDefaultNormalizer } from '@testing-library/react'
 import React, { Component } from 'react'
 import ApiHelper from '../../ApiHelper/ApiHelper'
 import Bookshelf from '../Bookshelf/Bookshelf'
+import PublishedStory from '../PublishedStory/PublishedStory'
 
 class LibraryView extends Component {
   constructor() {
     super()
     this.state = {
       stories: [],
-      currentStory: {}
+      currentStory: {
+        story: [],
+        title: '',
+        updated_at: '',
+        prompt: ''
+      }
     }
   }
 
@@ -35,6 +41,11 @@ class LibraryView extends Component {
           stories={this.state.stories}
           onClick={this.selectStoryToRead}
         />
+      {this.state.currentStory.story.length > 0 
+        && <PublishedStory 
+          currentStory={this.state.currentStory}
+          />
+      }
       </>
     );
   }

--- a/src/components/LibraryView/LibraryView.js
+++ b/src/components/LibraryView/LibraryView.js
@@ -1,4 +1,3 @@
-import { getDefaultNormalizer } from '@testing-library/react'
 import React, { Component } from 'react'
 import ApiHelper from '../../ApiHelper/ApiHelper'
 import Bookshelf from '../Bookshelf/Bookshelf'

--- a/src/components/LibraryView/LibraryView.test.js
+++ b/src/components/LibraryView/LibraryView.test.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { screen, render, fireEvent } from "@testing-library/react";
+import LibraryView from "./LibraryView";
+import testData from "../../assets/testData/testData";
+import ApiHelper from '../../ApiHelper/ApiHelper'
+jest.mock('../../ApiHelper/ApiHelper.js')
+
+describe('LibraryView component', () => {
+
+  beforeEach(() => {
+    ApiHelper.getData.mockResolvedValueOnce(testData.stories)
+    render(<LibraryView />)
+  })
+  
+  it('should fetch stories on render', () => {
+    expect(ApiHelper.getData).toHaveBeenCalledTimes(1)
+  })
+  
+  it('should render a book button for every COMPLETED story', () => {
+    const buttons = screen.getAllByRole('button')
+    expect(buttons).toHaveLength(3)
+  })
+  
+  it('should display a story when a button is clicked', () => {
+    const button = screen.getByText('Birdhouse in Your Soul')
+    ApiHelper.getData.mockResolvedValueOnce(['Khalid Williams'])
+    fireEvent.click(button)
+    const title = screen.getByRole('heading', { 
+      name: 'Birdhouse in Your Soul'
+    })
+    expect(title).toBeInTheDocument()
+  })
+  
+  it(`should display a different story 
+  when a different button is clicked`, () => {
+    const button1 = screen.getByText('Birdhouse in Your Soul')
+    const button2 = screen.getByText('Greyson has a good morning')
+    
+    ApiHelper.getData.mockResolvedValueOnce(['Khalid Williams'])
+    fireEvent.click(button1)
+    
+    ApiHelper.getData.mockResolvedValueOnce(['Greyson Elkins'])
+    fireEvent.click(button2)
+
+    expect(screen.queryByRole('heading', {
+      name: 'Birdhouse in Your Soul'
+    })).not.toBeInTheDocument()
+
+    expect(screen.getByRole('heading', {
+      name: 'Greyson has a good morning'
+    })).toBeInTheDocument()
+  })
+})

--- a/src/components/PublishedStory/PublishedStory.css
+++ b/src/components/PublishedStory/PublishedStory.css
@@ -1,0 +1,14 @@
+article, header, h2, h3, h4 {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 0em;
+}
+
+header {
+  margin-bottom: 2em;
+}
+
+p {
+  margin: 0em;
+}

--- a/src/components/PublishedStory/PublishedStory.js
+++ b/src/components/PublishedStory/PublishedStory.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react'
+import moment from 'moment'
+import ApiHelper from '../../ApiHelper/ApiHelper'
+import './PublishedStory.css'
+
+class PublishedStory extends Component {
+  constructor(props) {
+    super(props)
+    this.story = this.buildStory(props.currentStory.story)
+    this.state = {
+      authors: []
+    }
+  }
+
+  buildStory = (story = []) => {
+    debugger
+    // console.log(story)
+    return story.map(section => {
+      return (
+        <p>{section}</p>
+      )
+    })
+  }
+
+  componentDidMount() {
+    const foundAuthors = [];
+    ApiHelper.getData().then(authors => {
+      console.log(authors)
+      // this will be fleshed out when getData and 
+      // authors in the database are fleshed out
+    })
+  }
+
+  render() {
+    return (
+      <article>
+        <header>
+          <h2>{this.props.currentStory.title}</h2>
+          <h4>
+            {moment(this.props.currentStory.updated_at).format('MMMM DD YYYY')} 
+            <br /> 
+            Prompt: {this.props.currentStory.prompt}
+          </h4>
+          <h3>By {this.state.authors}</h3>
+        </header>
+        <section>
+          {this.story}
+        </section>
+      </article>
+
+    )
+  }
+}
+
+export default PublishedStory

--- a/src/components/PublishedStory/PublishedStory.js
+++ b/src/components/PublishedStory/PublishedStory.js
@@ -10,22 +10,42 @@ class PublishedStory extends Component {
       authors: []
     }
   }
-
+  
+  componentDidMount() {
+    const foundAuthors = [];
+    ApiHelper.getData().then(authors => {
+      this.setState({
+        authors: [
+          "Greyson Elkins", 
+          "Carly Clift", 
+          "Nick Hart", 
+          "Aaron B.D."]
+        });
+        // this will be fleshed out when getData and 
+        // authors in the database are fleshed out
+      })
+    }
+    
   buildStory = (story = []) => {
-    return story.map(section => {
+    return story.map((section, i) => {
       return (
-        <p>{section}</p>
+        <p key={`paragraph${i}`}>{section}</p>
       )
     })
   }
 
-  componentDidMount() {
-    const foundAuthors = [];
-    ApiHelper.getData().then(authors => {
-      console.log(authors)
-      // this will be fleshed out when getData and 
-      // authors in the database are fleshed out
-    })
+  presentAuthors(authors) {
+    const authorCount = authors.length
+    return authors.reduce((list, author, i) => {
+      if (i + 1 === authorCount && authorCount !== 1) {
+        list += ` and ${author}`
+      } else if (i === 0) {
+        list += author
+      } else {
+        list += `, ${author}`
+      }
+      return list
+    }, 'By ')
   }
 
   render() {
@@ -38,7 +58,7 @@ class PublishedStory extends Component {
             <br /> 
             Prompt: {this.props.currentStory.prompt}
           </h4>
-          <h3>By {this.state.authors}</h3>
+          <h3>{this.presentAuthors(this.state.authors)}</h3>
         </header>
         <section>
           {this.buildStory(this.props.currentStory.story)}

--- a/src/components/PublishedStory/PublishedStory.js
+++ b/src/components/PublishedStory/PublishedStory.js
@@ -37,7 +37,7 @@ class PublishedStory extends Component {
         <header>
           <h2>{this.props.currentStory.title}</h2>
           <h4>
-            {moment(this.props.currentStory.updated_at).format('MMMM DD YYYY')} 
+            {moment(this.props.currentStory.updated_at).format('MMMM DD, YYYY')} 
             <br /> 
             Prompt: {this.props.currentStory.prompt}
           </h4>

--- a/src/components/PublishedStory/PublishedStory.js
+++ b/src/components/PublishedStory/PublishedStory.js
@@ -35,6 +35,11 @@ class PublishedStory extends Component {
   }
 
   presentAuthors(authors) {
+    //this function will eventually need to account 
+    //for multiples because REPEATS MUST BE maintained 
+    //in state in order to coodernate between entries
+    //and their respective users
+    
     const authorCount = authors.length
     return authors.reduce((list, author, i) => {
       if (i + 1 === authorCount && authorCount !== 1) {

--- a/src/components/PublishedStory/PublishedStory.test.js
+++ b/src/components/PublishedStory/PublishedStory.test.js
@@ -1,0 +1,47 @@
+import React from "react";
+import { screen, render, fireEvent } from "@testing-library/react";
+import moment from 'moment'
+import PublishedStory from "./PublishedStory";
+import testData from "../../assets/testData/testData";
+import ApiHelper from "../../ApiHelper/ApiHelper";
+
+jest.mock('../../ApiHelper/ApiHelper.js')
+
+describe('PublishedStory component', () => {
+
+  beforeEach(() => {
+    ApiHelper.getData.mockResolvedValueOnce([
+      'Greyson Elkins', 
+      'Carly Clift', 
+      'Nick Hart', 
+      'Aaron B.D.'
+    ])
+    render(<PublishedStory currentStory={testData.stories[2]}/>)
+  })
+
+  it('should render details about the story', () => {
+    const title = screen.getByRole('heading', { name: 'Birdhouse in Your Soul'})
+    const prompt = screen.getByRole('heading', { name: /sci-fi/i})
+    const date = screen.getByRole(
+      'heading',
+      { name: /October 10, 2020/i
+      })
+    const line1 = screen.getByText(
+      'Blue canary in the outlet by the lightswitch.'
+    );
+    const lastLine = screen.getByText(
+      "Say I'm the only bee in your bonnet."
+    )
+    const authors = screen.getByText(
+      /By Greyson Elkins, Carly Clift, Nick Hart and Aaron B.D./i
+    )
+    
+    expect(title).toBeInTheDocument()
+    expect(prompt).toBeInTheDocument()
+    expect(date).toBeInTheDocument()
+    expect(line1).toBeInTheDocument()
+    expect(lastLine).toBeInTheDocument()
+    expect(authors).toBeInTheDocument()
+  })
+
+})


### PR DESCRIPTION
#### What's this PR do?
* Allows the LibraryView to display individual stories in full
* Tests all components rendered by LibraryView
#### Where should the reviewer start?
LibraryView / PublishedStory, and their respective tests
#### How should this be manually tested?
Click it a few times
#### Any background context you want to provide?
1. Authors are being automatically rendered as **`us`** right now for tests. Fleshing out and actually using the return from `getData` shouldn't throw tests as they are now. 
1. `PublishedStory.presentAuthors` should be the place where duplicate authors are accounted for; duplicate authors from the database should persist into the state of `PublishedStory` if we want to make a feature where hovering on an author highlights their contributions. 
#### What are the relevant tickets?
close #17 #18 close #14
#### Questions:
"Background context 2" raises an interesting BE question: can there be duplicates in the relational key data base (authorsID vs. storyID) in the case that an author contributes to the same story twice? Do we want to allow authors to contribute to stories more than once?

